### PR TITLE
Fix env logging and docs 404

### DIFF
--- a/api/index.go
+++ b/api/index.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"log"
 	"net/http"
-	"os"
 	"sync"
 
 	"github.com/gorilla/handlers"
@@ -29,18 +28,6 @@ func initializeApp() {
 	// Загружаем переменные окружения (в Vercel они уже установлены)
 	if err := godotenv.Load(); err != nil {
 		log.Println("Warning: .env file not found (normal for Vercel)")
-	}
-
-	// Логируем важные переменные окружения для отладки
-	log.Printf("DEBUG: Environment variables check:")
-	envVars := []string{"MONGO_URI", "MONGODB_URI", "DATABASE_URL", "MONGO_URL", "TMDB_ACCESS_TOKEN", "JWT_SECRET"}
-	for _, envVar := range envVars {
-		value := os.Getenv(envVar)
-		if value != "" {
-			log.Printf("DEBUG: %s is set (length: %d)", envVar, len(value))
-		} else {
-			log.Printf("DEBUG: %s is NOT set", envVar)
-		}
 	}
 
 	// Инициализируем конфигурацию

--- a/pkg/handlers/docs.go
+++ b/pkg/handlers/docs.go
@@ -19,13 +19,9 @@ func NewDocsHandler() *DocsHandler {
 }
 
 func (h *DocsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Обслуживаем статические файлы для документации
-	if r.URL.Path == "/" {
-		h.serveDocs(w, r)
-		return
-	}
-	
-	http.NotFound(w, r)
+	// Обслуживаем документацию для всех путей
+	// Это нужно для правильной работы Scalar API Reference
+	h.serveDocs(w, r)
 }
 
 func (h *DocsHandler) RedirectToDocs(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Removes verbose .env logging and fixes the `/docs` endpoint to correctly display Scalar API documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b4f9684-e4c9-4b1b-b4c1-03ace472e501">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b4f9684-e4c9-4b1b-b4c1-03ace472e501">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

