### PR TITLE
feat: integrate official Scalar Go library for documentation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module neomovies-api
 
-go 1.21
+go 1.22.0
+
+toolchain go1.24.2
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.0
@@ -13,6 +15,7 @@ require (
 )
 
 require (
+	github.com/MarceloPetrucio/go-scalar-api-reference v0.0.0-20240521013641-ce5d2efe0e06 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MarceloPetrucio/go-scalar-api-reference v0.0.0-20240521013641-ce5d2efe0e06 h1:W4Yar1SUsPmmA51qoIRb174uDO/Xt3C48MB1YX9Y3vM=
+github.com/MarceloPetrucio/go-scalar-api-reference v0.0.0-20240521013641-ce5d2efe0e06/go.mod h1:/wotfjM8I3m8NuIHPz3S8k+CCYH80EqDT8ZeNLqMQm0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/handlers/docs.go
+++ b/pkg/handlers/docs.go
@@ -3,9 +3,10 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"net/http"
 	"os"
+
+	"github.com/MarceloPetrucio/go-scalar-api-reference"
 )
 
 type DocsHandler struct {
@@ -44,67 +45,21 @@ func (h *DocsHandler) serveDocs(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	tmpl := `<!DOCTYPE html>
-<html>
-<head>
-    <title>Neo Movies API Documentation</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <style>
-        body {
-            margin: 0;
-            padding: 0;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
-    </style>
-</head>
-<body>
-    <div id="api-reference"></div>
-    <script type="module">
-        import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@latest/dist/browser/standalone.js'
-        
-        createApiReference({
-            element: '#api-reference',
-            configuration: {
-                theme: 'saturn',
-                layout: 'modern',
-                defaultHttpClient: {
-                    targetKey: 'javascript',
-                    clientKey: 'fetch'
-                },
-                authentication: {
-                    securitySchemes: {
-                        bearerAuth: {
-                            type: 'http',
-                            scheme: 'bearer',
-                            bearerFormat: 'JWT'
-                        }
-                    }
-                },
-                spec: {
-                    url: '{{.BaseURL}}/openapi.json'
-                },
-                metadata: {
-                    title: 'Neo Movies API',
-                    description: 'Современный API для поиска фильмов и сериалов с поддержкой авторизации',
-                    favicon: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/browser/favicon.ico'
-                }
-            }
-        })
-    </script>
-</body>
-</html>`
+	htmlContent, err := scalar.ApiReferenceHTML(&scalar.Options{
+		SpecURL: fmt.Sprintf("%s/openapi.json", baseURL),
+		CustomOptions: scalar.CustomOptions{
+			PageTitle: "Neo Movies API Documentation",
+		},
+		DarkMode: true,
+	})
 
-	t, err := template.New("docs").Parse(tmpl)
 	if err != nil {
-		http.Error(w, "Template error", http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Error generating documentation: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	t.Execute(w, map[string]string{
-		"BaseURL": baseURL,
-	})
+	fmt.Fprintln(w, htmlContent)
 }
 
 type OpenAPISpec struct {


### PR DESCRIPTION
- Add github.com/MarceloPetrucio/go-scalar-api-reference dependency
- Replace custom HTML template with official Scalar library
- Use scalar.ApiReferenceHTML() for proper documentation generation
- Enable dark mode for better user experience
- Simplify documentation handler implementation
- Remove manual HTML template and JavaScript integration