### PR TITLE
Add go route for external ids

### DIFF
--- a/api/index.go
+++ b/api/index.go
@@ -123,6 +123,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	api.HandleFunc("/movies/{id}", movieHandler.GetByID).Methods("GET")
 	api.HandleFunc("/movies/{id}/recommendations", movieHandler.GetRecommendations).Methods("GET")
 	api.HandleFunc("/movies/{id}/similar", movieHandler.GetSimilar).Methods("GET")
+	api.HandleFunc("/movies/{id}/external-ids", movieHandler.GetExternalIDs).Methods("GET")
 
 	// Маршруты для сериалов
 	api.HandleFunc("/tv/search", tvHandler.Search).Methods("GET")
@@ -133,6 +134,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	api.HandleFunc("/tv/{id}", tvHandler.GetByID).Methods("GET")
 	api.HandleFunc("/tv/{id}/recommendations", tvHandler.GetRecommendations).Methods("GET")
 	api.HandleFunc("/tv/{id}/similar", tvHandler.GetSimilar).Methods("GET")
+	api.HandleFunc("/tv/{id}/external-ids", tvHandler.GetExternalIDs).Methods("GET")
 
 	// Приватные маршруты (требуют авторизации)
 	protected := api.PathPrefix("").Subrouter()

--- a/pkg/handlers/movie.go
+++ b/pkg/handlers/movie.go
@@ -258,6 +258,27 @@ func (h *MovieHandler) RemoveFromFavorites(w http.ResponseWriter, r *http.Reques
 	})
 }
 
+func (h *MovieHandler) GetExternalIDs(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid movie ID", http.StatusBadRequest)
+		return
+	}
+
+	externalIDs, err := h.movieService.GetExternalIDs(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(models.APIResponse{
+		Success: true,
+		Data:    externalIDs,
+	})
+}
+
 func getIntQuery(r *http.Request, key string, defaultValue int) int {
 	str := r.URL.Query().Get(key)
 	if str == "" {

--- a/pkg/handlers/tv.go
+++ b/pkg/handlers/tv.go
@@ -183,3 +183,24 @@ func (h *TVHandler) GetSimilar(w http.ResponseWriter, r *http.Request) {
 		Data:    tvShows,
 	})
 }
+
+func (h *TVHandler) GetExternalIDs(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid TV show ID", http.StatusBadRequest)
+		return
+	}
+
+	externalIDs, err := h.tvService.GetExternalIDs(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(models.APIResponse{
+		Success: true,
+		Data:    externalIDs,
+	})
+}

--- a/pkg/services/movie.go
+++ b/pkg/services/movie.go
@@ -104,3 +104,7 @@ func (s *MovieService) GetFavorites(userID string, language string) ([]models.Mo
 	
 	return movies, nil
 }
+
+func (s *MovieService) GetExternalIDs(id int) (*models.ExternalIDs, error) {
+	return s.tmdb.GetMovieExternalIDs(id)
+}

--- a/pkg/services/tv.go
+++ b/pkg/services/tv.go
@@ -49,3 +49,7 @@ func (s *TVService) GetRecommendations(id, page int, language string) (*models.T
 func (s *TVService) GetSimilar(id, page int, language string) (*models.TMDBTVResponse, error) {
 	return s.tmdb.GetSimilarTVShows(id, page, language)
 }
+
+func (s *TVService) GetExternalIDs(id int) (*models.ExternalIDs, error) {
+	return s.tmdb.GetTVExternalIDs(id)
+}


### PR DESCRIPTION
Add Go routes for fetching external IDs for movies and TV series to match existing JS functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4775228-f856-45e9-89b3-67d45da28430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4775228-f856-45e9-89b3-67d45da28430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

